### PR TITLE
Default to /cypress/logs/ directory for output

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Add an NPM script `failed-test` that will get the name of the JSON file
 with failed test details.
 
 ```json
+// package.json
 {
   "scripts": {
     "failed-test": "echo Test failed, details in $1"
@@ -41,7 +42,7 @@ channel, etc.
 
 ## JSON file fields
 
-The saved JSON file will have the following properties (see
+The saved JSON file will live in `cypress/logs/` and have the following properties (see
 [src/index.js](src/index.js#L67))
 
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const reject = require('lodash.reject')
 const path = require('path')
 
 const cleanupFilename = s => kebabCase(deburr(s))
+const getFilepath = filename => `cypress/logs/${filename}`
 const useSingleQuotes = s => Cypress._.replace(
   Cypress._.replace(s, /'/g, "\\'"),
   /"/g, "'"
@@ -28,7 +29,8 @@ function writeFailedTestInfo ({
   const str = JSON.stringify(info, null, 2) + '\n'
   const cleaned = cleanupFilename(testName)
   const filename = `failed-${cleaned}.json`
-  cy.writeFile(filename, str)
+  const filepath = getFilepath(filename)
+  cy.writeFile(filepath, str)
     .log('saved failed test information')
 
   // work around shell ENOENT failure in CI container
@@ -51,7 +53,8 @@ function writeFailedTestInfo ({
     console.log('running cy.exec has failed')
     console.log(result)
     cy.log(JSON.stringify(result))
-    cy.writeFile('failed-exec.json', JSON.stringify(result, null, 2))
+    const failedExecFilepath = getFilepath('failed-exec.json')
+    cy.writeFile(failedExecFilepath, JSON.stringify(result, null, 2))
   }
 
   cy.exec(candidates[0], options)

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const reject = require('lodash.reject')
 const path = require('path')
 
 const cleanupFilename = s => kebabCase(deburr(s))
-const getFilepath = filename => `cypress/logs/${filename}`
+const getFilepath = filename => path.join('cypress', 'logs', filename)
 const useSingleQuotes = s => Cypress._.replace(
   Cypress._.replace(s, /'/g, "\\'"),
   /"/g, "'"
@@ -45,7 +45,7 @@ function writeFailedTestInfo ({
   const options = {
     failOnNonZeroExit: false,
     env: {
-      FAILED_FILENAME: filename
+      FAILED_FILENAME: filepath
     }
   }
 
@@ -72,7 +72,7 @@ function writeFailedTestInfo ({
         onFailedExec(result)
       }
     })
-    // .log('ran "npm run failed-test" with the failed test filename', filename)
+    // .log('ran "npm run failed-test" with the failed test filename', filepath)
     .then(result => {
       console.log('exec output')
       console.log(result)

--- a/test/verify-failed-json.js
+++ b/test/verify-failed-json.js
@@ -17,9 +17,12 @@ const screenshotsFolder = inParentFolder(
   cypress.screenshotsFolder || 'cypress/screenshots')
 console.log('screenshots in folder', screenshotsFolder)
 
+const logsFolder = inParentFolder('cypress/logs');
+console.log('logs in folder', logsFolder)
+
 function checkJsonFile (filename) {
   la(is.unemptyString(filename), 'expected filename', filename)
-  const jsonFilename = inParentFolder(filename)
+  const jsonFilename = path.join(logsFolder, filename)
   la(fs.existsSync(jsonFilename), 'cannot find json file', jsonFilename)
 
   const result = require(jsonFilename)


### PR DESCRIPTION
Instead of creating log files in the project root directory, create them in `cypress/logs/`. Here are a few reasons why:

- easier to `gitignore`
- easier to upload as artifacts on CI alongside screenshots
- follows pattern of screenshots in Cypress that are created in the `cypress/screenshots/` folder

Partially addresses #18. It would be great to make this configurable, but I wasn't sure how you wanted to specify CLI args. This seemed like a sensible default for the time being.