### PR TITLE
Use util.inspect instead of JSON.stringify to avoid errors with undefined or null objects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const kebabCase = require('lodash.kebabcase')
 const deburr = require('lodash.deburr')
 const reject = require('lodash.reject')
 const path = require('path')
+const util = require('util')
 
 const cleanupFilename = s => kebabCase(deburr(s))
 const getFilepath = filename => path.join('cypress', 'logs', filename)
@@ -26,7 +27,7 @@ function writeFailedTestInfo ({
     testCommands,
     screenshot
   }
-  const str = JSON.stringify(info, null, 2) + '\n'
+  const str = util.inspect(info) + '\n'
   const cleaned = cleanupFilename(testName)
   const filename = `failed-${cleaned}.json`
   const filepath = getFilepath(filename)
@@ -52,9 +53,9 @@ function writeFailedTestInfo ({
   function onFailedExec (result) {
     console.log('running cy.exec has failed')
     console.log(result)
-    cy.log(JSON.stringify(result))
+    cy.log(util.inspect(result))
     const failedExecFilepath = getFilepath('failed-exec.json')
-    cy.writeFile(failedExecFilepath, JSON.stringify(result, null, 2))
+    cy.writeFile(failedExecFilepath, util.inspect(result))
   }
 
   cy.exec(candidates[0], options)
@@ -82,7 +83,7 @@ function writeFailedTestInfo ({
 
 var loggedCommands = []
 
-const stringify = x => useSingleQuotes(JSON.stringify(x))
+const stringify = x => useSingleQuotes(util.inspect(x))
 
 const isSimple = x =>
   Cypress._.isString(x) ||

--- a/test/verify-failed-json.js
+++ b/test/verify-failed-json.js
@@ -17,7 +17,7 @@ const screenshotsFolder = inParentFolder(
   cypress.screenshotsFolder || 'cypress/screenshots')
 console.log('screenshots in folder', screenshotsFolder)
 
-const logsFolder = inParentFolder('cypress/logs');
+const logsFolder = inParentFolder('cypress/logs')
 console.log('logs in folder', logsFolder)
 
 function checkJsonFile (filename) {


### PR DESCRIPTION
### Issue
I was running into issues with `JSON.stringify` after a `cy.click({ force: true })` event that were not caused before I introduced this logger.

```
TypeError: Converting circular structure to JSON
--
  | at JSON.stringify (<anonymous>)
  | at stringify (http://test:8080/__cypress/tests?p=cypress/support/index.js-121:172:45)
  | at $Cypress.Cypress.on (http://test:8080/__cypress/tests?p=cypress/support/index.js-121:186:57)

```

This would cause an uncaught exception, which would break my tests (ironically). After some debugging, I realized that the `click` events have `args` which have keys (like `x` and `y`) with `null` and `undefined` as values for a `force` click, which were causing the issues for `JSON.stringify`. 


### Proposed solution

Use the built in node [`util`](https://nodejs.org/api/util.html#util_util_inspect_object_options) package and the `inspect` function since it does not error on undefined or null keys.
> The util.inspect() method returns a string representation of object that is intended for debugging. 

