### PR TITLE
Fix circular ref logging and intercept spy logs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -114,6 +114,12 @@ function startLogging () {
       loggedCommands.push(str)
     }
   })
+
+  Cypress.on('log:added', ({ name, message }) => {
+    if (name.startsWith('spy-') && message !== undefined) {
+      loggedCommands.push(`${name} - ${message}`)
+    }
+  })
 }
 
 function initLog () {

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const kebabCase = require('lodash.kebabcase')
 const deburr = require('lodash.deburr')
 const reject = require('lodash.reject')
 const path = require('path')
+const util = require('util')
 
 const cleanupFilename = s => kebabCase(deburr(s))
 const getFilepath = filename => path.join('cypress', 'logs', filename)
@@ -52,9 +53,9 @@ function writeFailedTestInfo ({
   function onFailedExec (result) {
     console.log('running cy.exec has failed')
     console.log(result)
-    cy.log(JSON.stringify(result))
+    cy.log(util.inspect(result))
     const failedExecFilepath = getFilepath('failed-exec.json')
-    cy.writeFile(failedExecFilepath, JSON.stringify(result, null, 2))
+    cy.writeFile(failedExecFilepath, util.inspect(result))
   }
 
   cy.exec(candidates[0], options)
@@ -82,7 +83,7 @@ function writeFailedTestInfo ({
 
 var loggedCommands = []
 
-const stringify = x => useSingleQuotes(JSON.stringify(x))
+const stringify = x => useSingleQuotes(util.inspect(x))
 
 const isSimple = x =>
   Cypress._.isString(x) ||
@@ -96,7 +97,7 @@ function startLogging () {
   // or combination of both to keep track?
   // hmm, not every command seems to show up in command:end
   Cypress.on('command:end', ({attributes}) => {
-    const str = attributes.name + ' ' + attributes.args.map(stringify).join(' ')
+    const str = attributes.name + ' ' + attributes.args.map(x => util.inspect(x, { compact: false })).join(' ')
 
     if (isSimple(attributes.subject)) {
       try {


### PR DESCRIPTION
I came across the same issue as reported in #24 and had the same idea for fixing it as in #23. I really should have checked the PR list first. 

As far as I can tell, the log file is still valid JSON, which is what I think you had an issue with before.

For my use-case, I also needed spy logs as this, in combination with spying on `console.log` means I can harvest browser console logs for failing tests as well.