### PR TITLE
Add more log details for xhr commands

### DIFF
--- a/__snapshots__/cypress-failed-log-spec.js
+++ b/__snapshots__/cypress-failed-log-spec.js
@@ -1,3 +1,16 @@
+exports['saved commands failed test in test-page2-spec'] = [
+  "visit test-page2.html",
+  "get #triggerXHR",
+  "click ",
+  "xhr  GET http://localhost:9999/test-page2.json",
+  "xhr  STUBBED GET http://localhost:9999/test-page3.json",
+  "log fail on purpose, no such text",
+  "wrap {foo: bar}",
+  "assert expected **{ foo: bar }** to deeply equal **{ foo: bar }**",
+  "contains this text does not exist",
+  "assert expected **{ Object (length, prevObject, ...) }** to be **visible**"
+]
+
 exports['saved commands failed test in test-page1-spec'] = [
   "visit test-page1.html",
   "log fail on purpose, no such text",
@@ -27,6 +40,14 @@ exports['spec a.js finished with'] = {
 }
 
 exports['spec test-page1-spec.js finished with'] = {
+  "totalTests": 1,
+  "totalFailed": 1,
+  "totalPassed": 0,
+  "totalPending": 0,
+  "totalSkipped": 0
+}
+
+exports['spec test-page2-spec.js finished with'] = {
   "totalTests": 1,
   "totalFailed": 1,
   "totalPassed": 0,

--- a/cypress/integration/test-page2-spec.js
+++ b/cypress/integration/test-page2-spec.js
@@ -1,0 +1,20 @@
+describe('cypress failed log', () => {
+  beforeEach(function openUrl () {
+    cy.visit('test-page2.html')
+  })
+
+  // this test fails on purpose
+  it('finds xhr', () => {
+    cy.server();
+    cy.route('GET', '/test-page3.json', ['mock data'])
+    cy.get('#triggerXHR').click()
+    cy.log('fail on purpose, no such text')
+    cy
+      .wrap({ foo: 'bar' })
+      .then(o => {
+        console.log('there is an object')
+      })
+      .should('deep.equal', { foo: 'bar' })
+    cy.contains('this text does not exist').should('be.visible')
+  })
+})

--- a/src/cypress-failed-log-spec.js
+++ b/src/cypress-failed-log-spec.js
@@ -116,4 +116,55 @@ describe('cypress-failed-log', () => {
         )
       })
   })
+
+  it('runs spec test-page2-spec', () => {
+    const spec = 'cypress/integration/test-page2-spec.js'
+    terminalBanner(`Starting spec ${spec} at ${new Date()}`, '*')
+
+    return cypress
+      .run({
+        spec
+      })
+      .tap(() => {
+        terminalBanner(
+          `Cypress run finished for: ${spec} at ${new Date()}`,
+          '*'
+        )
+      })
+      .then(
+        pick([
+          'totalTests',
+          'totalFailed',
+          'totalPassed',
+          'totalPending',
+          'totalSkipped'
+        ])
+      )
+      .then(tests => {
+        debug('finished tests stats for test-page2-spec %o', tests)
+        snapshot('spec test-page2-spec.js finished with', tests)
+      })
+      .then(() => {
+        const logFilename = join(
+          __dirname,
+          '..',
+          'cypress',
+          'logs',
+          'failed-cypress-failed-log-finds-xhr.json'
+        )
+        la(existsSync(logFilename), 'cannot find file', logFilename)
+        const saved = require(logFilename)
+        saved.testCommands = saved.testCommands.map((command) => {
+          if (command.substring(0, 3) === 'xhr') {
+            return command.replace(/localhost:[0-9]+/, 'localhost:9999')
+          } else {
+            return command
+          }
+        })
+        snapshot(
+          'saved commands failed test in test-page2-spec',
+          saved.testCommands
+        )
+      })
+  })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -55,12 +55,12 @@ function startLogging () {
       return
     }
     if (options.instrument === 'command' && options.consoleProps) {
-      let detailMessage = '';
+      let detailMessage = ''
       if (options.name === 'xhr') {
         detailMessage = (options.consoleProps.Stubbed === 'Yes' ? 'STUBBED ' : '') + options.consoleProps.Method + ' ' + options.consoleProps.URL
       }
       const log = {
-        message: options.name + ' ' + options.message + ' ' + detailMessage
+        message: options.name + ' ' + options.message + (detailMessage !== '' ? ' ' + detailMessage : '')
       }
       debug(log)
       loggedCommands.push(log)

--- a/src/index.js
+++ b/src/index.js
@@ -55,8 +55,12 @@ function startLogging () {
       return
     }
     if (options.instrument === 'command' && options.consoleProps) {
+      let detailMessage = '';
+      if (options.name === 'xhr') {
+        detailMessage = (options.consoleProps.Stubbed === 'Yes' ? 'STUBBED ' : '') + options.consoleProps.Method + ' ' + options.consoleProps.URL
+      }
       const log = {
-        message: options.name + ' ' + options.message
+        message: options.name + ' ' + options.message + ' ' + detailMessage
       }
       debug(log)
       loggedCommands.push(log)

--- a/test-page2.html
+++ b/test-page2.html
@@ -1,0 +1,14 @@
+<script type="text/javascript">
+    function triggerXHR() {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', 'test-page2.json', true);
+        xhr.send(null);
+        xhr = new XMLHttpRequest();
+        xhr.open('GET', 'test-page3.json', true);
+        xhr.send(null);
+    }
+</script>
+
+<body>
+    <button id="triggerXHR" onClick="triggerXHR()">Trigger XHR</button>
+</body>

--- a/test-page2.json
+++ b/test-page2.json
@@ -1,0 +1,3 @@
+{
+    "some": "test data"
+}


### PR DESCRIPTION
The code change adds more details to the xhr command log.

Log before the change:
```
xhr
```

Log after the change:
```
xhr GET someUrlPath
xhr STUBBED GET someUrlPath
```

What was yet not obvious to me is how cypress handles the status changes for the xhr commands as currently with log added point in time the request status is always pending - thus similarity to the cypress console where the final response status is seen cannot yet be achieved - still the additional output of method and request path as well as the subbed indicator add a lot of value already to our usage of cypress.

fixes #120 