### PR TITLE
feat: remove screenshotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ suiteName - the parent suite name
 testName - full name of the test, including the suite name
 testError - error message string
 testCommands - array of strings, last failing command is last
-screenshot - filename of PNG file taken right after failure
 ```
 
 ## Example
@@ -75,8 +74,7 @@ and each test command before the test are recorded
     "assert expected **#/about** to equal **#/about**",
     "contains Join Us",
     "assert expected **body :not(script):contains(**'Join Us'**), [type='submit'][value~='Join Us']** to exist in the DOM"
-  ],
-  "screenshot": "loads-the-about-tab.png"
+  ]
 }
 ```
 

--- a/cypress/integration/test-page1-spec.js
+++ b/cypress/integration/test-page1-spec.js
@@ -5,7 +5,7 @@ describe('cypress failed log', () => {
 
   afterEach(function makeDummyCommands () {
     // more dummy commands on purpose. Can we get
-    // the right screenshot when the test actual failed?
+    // the right command list when the actual test failed?
     cy
       .wait(100)
       .wait(100)

--- a/package.json
+++ b/package.json
@@ -98,5 +98,8 @@
   "dependencies": {
     "debug": "4.1.1",
     "logdown": "3.3.0"
+  },
+  "release": {
+    "analyzeCommits": "simple-commit-message"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -20,8 +20,7 @@ function writeFailedTestInfo ({
   testId,
   testName,
   testError,
-  testCommands,
-  screenshot
+  testCommands
 }) {
   const info = {
     specName,
@@ -30,8 +29,7 @@ function writeFailedTestInfo ({
     testId,
     testName,
     testError,
-    testCommands,
-    screenshot
+    testCommands
   }
   const str = JSON.stringify(info, null, 2) + '\n'
   const cleaned = getCleanFilename(
@@ -101,11 +99,6 @@ function onFailed () {
   doneWithTest(testName)
 
   const title = this.currentTest.title
-  const screenshotName = `${getCleanFilename(title)} (failed)`
-
-  cy.wait(1000).log('waited for UI before capturing screenshot')
-  cy.screenshot(screenshotName)
-  cy.wait(1000)
 
   const suiteName = this.currentTest.parent && this.currentTest.parent.title
 
@@ -121,8 +114,6 @@ function onFailed () {
 
   const specName = path.basename(window.location.pathname)
 
-  const screenshot = `${screenshotName}.png`
-
   console.log('=== test failed ===')
   console.log(specName)
   console.log('=== title ===')
@@ -135,8 +126,6 @@ function onFailed () {
   console.log(testError)
   console.log('=== commands ===')
   console.log(testCommands.join('\n'))
-  console.log('=== screenshot ===')
-  console.log(screenshot)
 
   const info = {
     specName,
@@ -145,8 +134,7 @@ function onFailed () {
     testId,
     testName,
     testError,
-    testCommands,
-    screenshot
+    testCommands
   }
   writeFailedTestInfo(info)
 
@@ -154,10 +142,9 @@ function onFailed () {
 }
 
 //   We have to do a hack to make sure OUR "afterEach" callback function
-// runs BEFORE any user supplied "afterEach" callback. This is necessary
-// to take screenshot of the failure AS SOON AS POSSIBLE.
-//   Otherwise commands executed by the user callback might destroys the
-// screen and add too many commands to the log, making post-mortem
+// runs BEFORE any user supplied "afterEach" callback.
+//   Otherwise commands executed by the user callback might
+// add too many commands to the log, making post-mortem
 // triage very difficult. In this case we just wrap client supplied
 // "afterEach" function with our callback "onFailed". This ensures we run
 // first.
@@ -179,8 +166,7 @@ afterEach = (name, fn) => {
     fn = name
     name = fn.name
   }
-  // before running the client function "fn"
-  // run our "onFailed" to capture the screenshot sooner
+  // run our "onFailed" before running the client function "fn"
   _afterEach(name, function () {
     // run callbacks with context "this"
     onFailed.call(this)

--- a/test/verify-failed-json.js
+++ b/test/verify-failed-json.js
@@ -12,11 +12,6 @@ const jsonFiles = [
   'failed-cypress-failed-log-finds-aliens.json'
 ]
 
-const cypress = require(inParentFolder('cypress.json'))
-const screenshotsFolder = inParentFolder(
-  cypress.screenshotsFolder || 'cypress/screenshots')
-console.log('screenshots in folder', screenshotsFolder)
-
 const logsFolder = inParentFolder('cypress/logs')
 console.log('logs in folder', logsFolder)
 
@@ -43,12 +38,6 @@ function checkJsonFile (filename) {
 
   la(result.testCommands[0].startsWith('visit'),
     'expected first command to be visit', result.testCommands)
-
-  const screenshot = result.screenshot
-  la(is.unemptyString(screenshot), 'could not find screenshot', result)
-  const screenshotFilename = path.join(screenshotsFolder, screenshot)
-  la(fs.existsSync(screenshotFilename),
-    'could not find screenshot image', screenshotFilename)
 
   console.log('file %s looks ok', jsonFilename)
 }


### PR DESCRIPTION
Core Cypress already takes screenshots on failed tests.

It wasn't clear to me whether the "hack" about making sure this plugin's `afterEach` is called before any  user-supplied `afterEach` is still necessary. Part of the comment suggested that it was also to ensure the command list didn't get cluttered, so I left it.

Resolves #204.