### PR TITLE
Fix Cypress v9.2.0 incompatibility

### DIFF
--- a/cypress/e2e/test-skipping.cy.js
+++ b/cypress/e2e/test-skipping.cy.js
@@ -1,0 +1,11 @@
+describe('cypress skipped tests', () => {
+  it.skip('Skipping using it.skip', () => {})
+
+  it('Skipping using this.skip()', function() {
+    this.skip();
+  })
+
+  it('Skipping using this.skip() again', function() {
+    this.skip();
+  })
+})

--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,7 @@ function initLog () {
 
 function onFailed () {
   savingCommands = false
-  if (this.currentTest.state === 'passed') {
+  if (this.currentTest.state === 'passed' || this.currentTest.state === 'pending') {
     return
   }
   const testName = this.currentTest.fullTitle()


### PR DESCRIPTION
If you have a test that calls `this.skip()`, cypress-failed-log will throw an "Cannot read properties of undefined (reading 'message')" exception. If there's multiple such tests, it just stalls forever.
![Screen Shot 2022-08-23 at 10 08 38 AM](https://user-images.githubusercontent.com/651224/188028108-b068320d-d61a-4809-adca-db854e663180.png)

This is due to a change in Cypress 9.2.0 where it no longer triggers the "failed" event for skipped tests:
https://github.com/cypress-io/cypress/commit/4a97a5244ed23414d19ef39f9ea0d1f06b97a6ce